### PR TITLE
Support for Google AppEngine urlfetch for OAuth2

### DIFF
--- a/common/tripper.go
+++ b/common/tripper.go
@@ -16,3 +16,13 @@ type Tripper interface {
 	// requests to.
 	Provider() Provider
 }
+
+var roundTripperInUse http.RoundTripper = http.DefaultTransport.(http.RoundTripper)
+
+func GetRoundTripper() http.RoundTripper {
+	return roundTripperInUse
+}
+
+func SetRoundTripper(t http.RoundTripper) {
+	roundTripperInUse = t
+}

--- a/oauth2/oauth2_tripper.go
+++ b/oauth2/oauth2_tripper.go
@@ -13,7 +13,7 @@ type OAuth2Tripper struct {
 
 // NewOAuth2Tripper creates a new OAuth2Tripper with the given arguments.
 func NewOAuth2Tripper(creds *common.Credentials, provider common.Provider) *OAuth2Tripper {
-	return &OAuth2Tripper{http.DefaultTransport, creds, provider}
+	return &OAuth2Tripper{common.GetRoundTripper(), creds, provider}
 }
 
 // RoundTrip is called by the http package when making a request to a server. This


### PR DESCRIPTION
To use http in Google AppEngine, you have to use urlfetch, not
the normal default http client or RoundTripper.  So similar to
what one of the forks of goauth2 did, this adds the ability via
the now-added common/SetRoundTripper to pass in the specific
RoundTripper to use.  If unset, the default net/http one will be
used.  However, by calling this method, you can pass in your own
including one created via urlfetch.  Here is sample code showing
it in use:

import (
  "appengine"
  "github.com/stretchr/gomniauth/common"
)

func SomeGolangFunc([...,] r *http.Request [,...]) {
  c := appengine.NewContext(r)
  t := new(urlfetch.Transport)
  t.Context = c
  common.SetRoundTripper(t)

  // Do something interesting here
}

Note that common.SetRoundTripper may have to be called in the GAE
server before every request, versus trying to do it once because
of the appengine.Context being passed in.  Pretty sure you cannot
pass in a nil *http.Request and re-use the context, so you can't
make the call during the GAE init() method.
